### PR TITLE
removed useless values folders

### DIFF
--- a/crystalrangeseekbar/src/main/res/values-large-hdpi/dimens.xml
+++ b/crystalrangeseekbar/src/main/res/values-large-hdpi/dimens.xml
@@ -1,7 +1,0 @@
-<resources>
-    <dimen name="thumb_width">30dp</dimen>
-    <dimen name="thumb_height">30dp</dimen>
-
-    <dimen name="bubble_thumb_width">70dp</dimen>
-    <dimen name="bubble_thumb_height">70dp</dimen>
-</resources>

--- a/crystalrangeseekbar/src/main/res/values-xhdpi/dimens.xml
+++ b/crystalrangeseekbar/src/main/res/values-xhdpi/dimens.xml
@@ -1,7 +1,0 @@
-<resources>
-    <dimen name="thumb_width">30dp</dimen>
-    <dimen name="thumb_height">30dp</dimen>
-
-    <dimen name="bubble_thumb_width">70dp</dimen>
-    <dimen name="bubble_thumb_height">70dp</dimen>
-</resources>

--- a/crystalrangeseekbar/src/main/res/values-xlarge-mdpi/dimens.xml
+++ b/crystalrangeseekbar/src/main/res/values-xlarge-mdpi/dimens.xml
@@ -1,7 +1,0 @@
-<resources>
-    <dimen name="thumb_width">30dp</dimen>
-    <dimen name="thumb_height">30dp</dimen>
-
-    <dimen name="bubble_thumb_width">70dp</dimen>
-    <dimen name="bubble_thumb_height">70dp</dimen>
-</resources>

--- a/crystalrangeseekbar/src/main/res/values-xxhdpi/dimens.xml
+++ b/crystalrangeseekbar/src/main/res/values-xxhdpi/dimens.xml
@@ -1,7 +1,0 @@
-<resources>
-    <dimen name="thumb_width">30dp</dimen>
-    <dimen name="thumb_height">30dp</dimen>
-
-    <dimen name="bubble_thumb_width">70dp</dimen>
-    <dimen name="bubble_thumb_height">70dp</dimen>
-</resources>

--- a/crystalrangeseekbar/src/main/res/values-xxxhdpi/dimens.xml
+++ b/crystalrangeseekbar/src/main/res/values-xxxhdpi/dimens.xml
@@ -1,7 +1,0 @@
-<resources>
-    <dimen name="thumb_width">30dp</dimen>
-    <dimen name="thumb_height">30dp</dimen>
-
-    <dimen name="bubble_thumb_width">70dp</dimen>
-    <dimen name="bubble_thumb_height">70dp</dimen>
-</resources>


### PR DESCRIPTION
Don't add values folders if they contains same values. It's only overhead when trying override thumb size.