### PR TITLE
Fix max_start_value not be applied

### DIFF
--- a/crystalrangeseekbar/src/main/java/com/crystal/crystalrangeseekbar/widgets/CrystalRangeSeekbar.java
+++ b/crystalrangeseekbar/src/main/java/com/crystal/crystalrangeseekbar/widgets/CrystalRangeSeekbar.java
@@ -848,7 +848,7 @@ public class CrystalRangeSeekbar extends View {
 
     private void setMaxStartValue() {
         if (maxStartValue <= absoluteMaxValue && maxStartValue > absoluteMinValue && maxStartValue >= absoluteMinStartValue) {
-            maxStartValue = Math.max(absoluteMaxStartValue, absoluteMinValue);
+            maxStartValue = Math.max(maxStartValue, absoluteMinValue);
             maxStartValue -= absoluteMinValue;
             maxStartValue = maxStartValue / (absoluteMaxValue - absoluteMinValue) * 100;
             setNormalizedMaxValue(maxStartValue);


### PR DESCRIPTION
Fix an issue where the initial value for the maximum thumb position was being ignored when set from
XML.